### PR TITLE
fix(provider): stop dropping user JSON fields and silence perma-diffs

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -111,7 +111,7 @@ func (c *PinotClient) CreateSchema(ctx context.Context, schema interface{}) erro
 }
 
 func (c *PinotClient) GetSchema(ctx context.Context, schemaName string) (map[string]interface{}, error) {
-	resp, err := c.doRequest(ctx, "GET", fmt.Sprintf("%s/schemas/%s", c.controllerURL, schemaName), nil)
+	resp, err := c.doRequest(ctx, "GET", fmt.Sprintf("%s/schemas/%s", c.controllerURL, url.PathEscape(schemaName)), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +142,7 @@ func (c *PinotClient) UpdateSchema(ctx context.Context, schemaName string, schem
 }
 
 func (c *PinotClient) DeleteSchema(ctx context.Context, schemaName string) error {
-	_, err := c.doRequest(ctx, "DELETE", fmt.Sprintf("%s/schemas/%s", c.controllerURL, schemaName), nil)
+	_, err := c.doRequest(ctx, "DELETE", fmt.Sprintf("%s/schemas/%s", c.controllerURL, url.PathEscape(schemaName)), nil)
 	return err
 }
 
@@ -153,7 +153,7 @@ func (c *PinotClient) CreateTable(ctx context.Context, tableConfig interface{}) 
 }
 
 func (c *PinotClient) GetTable(ctx context.Context, tableName string) (map[string]interface{}, error) {
-	resp, err := c.doRequest(ctx, "GET", fmt.Sprintf("%s/tables/%s", c.controllerURL, tableName), nil)
+	resp, err := c.doRequest(ctx, "GET", fmt.Sprintf("%s/tables/%s", c.controllerURL, url.PathEscape(tableName)), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -176,7 +176,7 @@ func (c *PinotClient) UpdateTable(ctx context.Context, tableName string, tableCo
 	if tableName == "" {
 		return fmt.Errorf("table name is required")
 	}
-	_, err := c.doRequest(ctx, "PUT", fmt.Sprintf("%s/tables/%s", c.controllerURL, tableName), tableConfig)
+	_, err := c.doRequest(ctx, "PUT", fmt.Sprintf("%s/tables/%s", c.controllerURL, url.PathEscape(tableName)), tableConfig)
 	return err
 }
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -19,6 +20,24 @@ type PinotClient struct {
 	username      string
 	password      string
 	token         string
+}
+
+// APIError is returned by doRequest for any non-2xx response, so callers can
+// branch on the HTTP status (e.g. treat 404 as "resource is gone") without
+// string-matching on the error message.
+type APIError struct {
+	Status int
+	Body   string
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("API error (status %d): %s", e.Status, e.Body)
+}
+
+// IsNotFound reports whether err is an APIError with HTTP 404.
+func IsNotFound(err error) bool {
+	var apiErr *APIError
+	return errors.As(err, &apiErr) && apiErr.Status == http.StatusNotFound
 }
 
 func NewPinotClient(controllerURL, username, password string) (*PinotClient, error) {
@@ -79,7 +98,7 @@ func (c *PinotClient) doRequest(ctx context.Context, method, url string, body in
 	}
 
 	if resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(respBody))
+		return nil, &APIError{Status: resp.StatusCode, Body: string(respBody)}
 	}
 
 	return respBody, nil
@@ -105,20 +124,20 @@ func (c *PinotClient) GetSchema(ctx context.Context, schemaName string) (map[str
 	return schema, nil
 }
 
-func (c *PinotClient) UpdateSchema(ctx context.Context, schema interface{}) error {
-	jsonBytes, err := json.Marshal(schema)
-	if err != nil {
-		return fmt.Errorf("failed to marshal schema: %w", err)
+// UpdateSchema PUTs the schema to /schemas/{schemaName}. When forceUpdate is
+// true, ?force=true is appended so the controller accepts backward-incompatible
+// changes (e.g. converting a column from singleValueField=true to false).
+// Without this flag, Pinot rejects such changes with
+// "Backward incompatible schema. Only allow adding new columns".
+func (c *PinotClient) UpdateSchema(ctx context.Context, schemaName string, schema interface{}, forceUpdate bool) error {
+	if schemaName == "" {
+		return fmt.Errorf("schema name is required")
 	}
-	var schemaMap map[string]interface{}
-	if err := json.Unmarshal(jsonBytes, &schemaMap); err != nil {
-		return fmt.Errorf("failed to unmarshal schema: %w", err)
+	endpoint := fmt.Sprintf("%s/schemas/%s", c.controllerURL, url.PathEscape(schemaName))
+	if forceUpdate {
+		endpoint += "?force=true"
 	}
-	schemaName, ok := schemaMap["schemaName"].(string)
-	if !ok {
-		return fmt.Errorf("schema name not found")
-	}
-	_, err = c.doRequest(ctx, "PUT", fmt.Sprintf("%s/schemas/%s", c.controllerURL, schemaName), schema)
+	_, err := c.doRequest(ctx, "PUT", endpoint, schema)
 	return err
 }
 
@@ -153,25 +172,33 @@ func (c *PinotClient) GetTable(ctx context.Context, tableName string) (map[strin
 	return response, nil
 }
 
-func (c *PinotClient) UpdateTable(ctx context.Context, tableConfig interface{}) error {
-	jsonBytes, err := json.Marshal(tableConfig)
-	if err != nil {
-		return fmt.Errorf("failed to marshal table config: %w", err)
+func (c *PinotClient) UpdateTable(ctx context.Context, tableName string, tableConfig interface{}) error {
+	if tableName == "" {
+		return fmt.Errorf("table name is required")
 	}
-	var tableMap map[string]interface{}
-	if err := json.Unmarshal(jsonBytes, &tableMap); err != nil {
-		return fmt.Errorf("failed to unmarshal table config: %w", err)
-	}
-	tableName, ok := tableMap["tableName"].(string)
-	if !ok {
-		return fmt.Errorf("table name not found")
-	}
-	_, err = c.doRequest(ctx, "PUT", fmt.Sprintf("%s/tables/%s", c.controllerURL, tableName), tableConfig)
+	_, err := c.doRequest(ctx, "PUT", fmt.Sprintf("%s/tables/%s", c.controllerURL, tableName), tableConfig)
 	return err
 }
 
-func (c *PinotClient) DeleteTable(ctx context.Context, tableName string) error {
-	_, err := c.doRequest(ctx, "DELETE", fmt.Sprintf("%s/tables/%s", c.controllerURL, tableName), nil)
+// DeleteTableByLogical deletes via DELETE /tables/{logical}?type={typ}, which is
+// the documented endpoint. Routes through the configured client (URL + auth)
+// rather than reading env vars directly.
+func (c *PinotClient) DeleteTableByLogical(ctx context.Context, logical, tableType string) error {
+	if logical == "" {
+		return fmt.Errorf("table name is required")
+	}
+	if tableType == "" {
+		return fmt.Errorf("table type is required")
+	}
+	endpoint := fmt.Sprintf("%s/tables/%s?type=%s",
+		c.controllerURL,
+		url.PathEscape(logical),
+		url.QueryEscape(strings.ToUpper(tableType)),
+	)
+	_, err := c.doRequest(ctx, "DELETE", endpoint, nil)
+	if IsNotFound(err) {
+		return nil
+	}
 	return err
 }
 
@@ -223,23 +250,12 @@ func (c *PinotClient) GetUser(ctx context.Context, username, component string) (
 	return m, nil
 }
 
-func (c *PinotClient) UpdateUser(ctx context.Context, user interface{}) error {
-	jsonBytes, err := json.Marshal(user)
-	if err != nil {
-		return fmt.Errorf("failed to marshal user: %w", err)
-	}
-	var m map[string]interface{}
-	if err := json.Unmarshal(jsonBytes, &m); err != nil {
-		return fmt.Errorf("failed to unmarshal user: %w", err)
-	}
-
-	username, _ := m["username"].(string)
-	component, _ := m["component"].(string)
+func (c *PinotClient) UpdateUser(ctx context.Context, username, component string, user interface{}) error {
 	if username == "" {
-		return fmt.Errorf("username not found")
+		return fmt.Errorf("username is required")
 	}
 	if component == "" {
-		return fmt.Errorf("component not found")
+		return fmt.Errorf("component is required")
 	}
 
 	v := url.Values{}
@@ -252,7 +268,7 @@ func (c *PinotClient) UpdateUser(ctx context.Context, user interface{}) error {
 		v.Encode(),
 	)
 
-	_, err = c.doRequest(ctx, "PUT", endpoint, user)
+	_, err := c.doRequest(ctx, "PUT", endpoint, user)
 	return err
 }
 

--- a/internal/provider/plan_modifiers.go
+++ b/internal/provider/plan_modifiers.go
@@ -1,0 +1,97 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// jsonNullsIgnoredPlanModifier suppresses planned changes when the plan and
+// state JSON differ only by the presence of null-valued object keys.
+//
+// Pinot's GET responses are stripped of null keys (see schema_resource.Read /
+// table_resource.Read), so state never carries `"foo": null`. Users, however,
+// often have `foo = null` in their HCL — either written explicitly or produced
+// by `jsonencode` of a conditional expression. Without this modifier every
+// plan shows `+ foo = null` against null-stripped state forever.
+//
+// We only collapse the plan to the state value when the two are JSON-equal
+// modulo nulls. Any real change still flows through normally.
+type jsonNullsIgnoredPlanModifier struct{}
+
+func JSONNullsIgnoredPlanModifier() planmodifier.String {
+	return jsonNullsIgnoredPlanModifier{}
+}
+
+func (m jsonNullsIgnoredPlanModifier) Description(_ context.Context) string {
+	return "Treat JSON values that differ only by null-valued keys as equal."
+}
+
+func (m jsonNullsIgnoredPlanModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m jsonNullsIgnoredPlanModifier) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	if req.PlanValue.IsNull() || req.PlanValue.IsUnknown() {
+		return
+	}
+	if req.StateValue.IsNull() || req.StateValue.IsUnknown() {
+		return
+	}
+
+	var planData, stateData interface{}
+	if err := json.Unmarshal([]byte(req.PlanValue.ValueString()), &planData); err != nil {
+		return
+	}
+	if err := json.Unmarshal([]byte(req.StateValue.ValueString()), &stateData); err != nil {
+		return
+	}
+
+	if reflect.DeepEqual(stripNullValues(stateData), stripNullValues(planData)) {
+		resp.PlanValue = req.StateValue
+	}
+}
+
+// saslJaasConfigPlanModifier preserves the sasl_jaas_config state value across
+// plans unless kafka_username or kafka_password actually change. Without this,
+// the attribute (Computed) plans as Unknown every time, so every plan shows a
+// synthetic sensitive-value change even when nothing relevant changed.
+type saslJaasConfigPlanModifier struct{}
+
+func SaslJaasConfigPlanModifier() planmodifier.String {
+	return saslJaasConfigPlanModifier{}
+}
+
+func (m saslJaasConfigPlanModifier) Description(_ context.Context) string {
+	return "Preserve sasl_jaas_config from state unless kafka_username or kafka_password change."
+}
+
+func (m saslJaasConfigPlanModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m saslJaasConfigPlanModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	if req.StateValue.IsUnknown() {
+		return
+	}
+
+	var planUser, stateUser, planPass, statePass types.String
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("kafka_username"), &planUser)...)
+	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("kafka_username"), &stateUser)...)
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("kafka_password"), &planPass)...)
+	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("kafka_password"), &statePass)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Inputs unchanged → carry state value (including null) into the plan, so
+	// Terraform doesn't report a synthetic diff against an Unknown computed
+	// value when the underlying credential isn't actually changing.
+	if planUser.Equal(stateUser) && planPass.Equal(statePass) {
+		resp.PlanValue = req.StateValue
+	}
+}

--- a/internal/provider/plan_modifiers.go
+++ b/internal/provider/plan_modifiers.go
@@ -43,17 +43,24 @@ func (m jsonNullsIgnoredPlanModifier) PlanModifyString(_ context.Context, req pl
 		return
 	}
 
-	var planData, stateData interface{}
-	if err := json.Unmarshal([]byte(req.PlanValue.ValueString()), &planData); err != nil {
-		return
-	}
-	if err := json.Unmarshal([]byte(req.StateValue.ValueString()), &stateData); err != nil {
-		return
-	}
-
-	if reflect.DeepEqual(stripNullValues(stateData), stripNullValues(planData)) {
+	if jsonEqualIgnoringNulls(req.StateValue.ValueString(), req.PlanValue.ValueString()) {
 		resp.PlanValue = req.StateValue
 	}
+}
+
+// jsonEqualIgnoringNulls reports whether two JSON documents are structurally
+// equal once null-valued object keys are stripped. Invalid JSON on either
+// side returns false (the caller should treat that as "not equal" and let the
+// real diff flow through).
+func jsonEqualIgnoringNulls(a, b string) bool {
+	var aData, bData interface{}
+	if err := json.Unmarshal([]byte(a), &aData); err != nil {
+		return false
+	}
+	if err := json.Unmarshal([]byte(b), &bData); err != nil {
+		return false
+	}
+	return reflect.DeepEqual(stripNullValues(aData), stripNullValues(bData))
 }
 
 // saslJaasConfigPlanModifier preserves the sasl_jaas_config state value across

--- a/internal/provider/plan_modifiers_test.go
+++ b/internal/provider/plan_modifiers_test.go
@@ -1,0 +1,144 @@
+package provider
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestStripNullValues(t *testing.T) {
+	tests := []struct {
+		name string
+		in   interface{}
+		want interface{}
+	}{
+		{
+			name: "drops null at top level",
+			in:   map[string]interface{}{"a": 1.0, "b": nil},
+			want: map[string]interface{}{"a": 1.0},
+		},
+		{
+			name: "drops null in nested map",
+			in: map[string]interface{}{
+				"outer": map[string]interface{}{"k": nil, "kept": "v"},
+			},
+			want: map[string]interface{}{
+				"outer": map[string]interface{}{"kept": "v"},
+			},
+		},
+		{
+			name: "preserves slice positions; recurses into element maps",
+			in: []interface{}{
+				map[string]interface{}{"a": 1.0, "b": nil},
+				"untouched",
+				nil,
+			},
+			want: []interface{}{
+				map[string]interface{}{"a": 1.0},
+				"untouched",
+				nil,
+			},
+		},
+		{
+			name: "passes through primitives",
+			in:   "hello",
+			want: "hello",
+		},
+		{
+			name: "passes through non-null map untouched",
+			in:   map[string]interface{}{"a": 1.0, "b": "x"},
+			want: map[string]interface{}{"a": 1.0, "b": "x"},
+		},
+		{
+			name: "Pinot-style field config with indexes:null",
+			in: map[string]interface{}{
+				"fieldConfigList": []interface{}{
+					map[string]interface{}{
+						"name":           "country_code",
+						"indexes":        nil,
+						"tierOverwrites": nil,
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"fieldConfigList": []interface{}{
+					map[string]interface{}{"name": "country_code"},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := stripNullValues(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("stripNullValues(%#v)\n got: %#v\nwant: %#v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestJSONEqualIgnoringNulls(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b string
+		want bool
+	}{
+		{
+			name: "identical objects",
+			a:    `{"name":"foo","dataType":"STRING"}`,
+			b:    `{"name":"foo","dataType":"STRING"}`,
+			want: true,
+		},
+		{
+			name: "object with explicit null vs same object without the key",
+			a:    `{"name":"foo","indexes":null}`,
+			b:    `{"name":"foo"}`,
+			want: true,
+		},
+		{
+			name: "key order does not matter",
+			a:    `{"a":1,"b":2}`,
+			b:    `{"b":2,"a":1}`,
+			want: true,
+		},
+		{
+			name: "real value differences are not collapsed",
+			a:    `{"name":"foo","dataType":"STRING"}`,
+			b:    `{"name":"foo","dataType":"INT"}`,
+			want: false,
+		},
+		{
+			name: "differing nested keys with one null still equal",
+			a:    `{"outer":{"a":1,"b":null}}`,
+			b:    `{"outer":{"a":1}}`,
+			want: true,
+		},
+		{
+			name: "nulls inside arrays are preserved (positional)",
+			a:    `{"list":[null,1]}`,
+			b:    `{"list":[1]}`,
+			want: false,
+		},
+		{
+			name: "invalid JSON returns false",
+			a:    `not json`,
+			b:    `{}`,
+			want: false,
+		},
+		{
+			name: "field config list — indexes:null suppressed",
+			a:    `{"fieldConfigList":[{"name":"x","indexes":null}]}`,
+			b:    `{"fieldConfigList":[{"name":"x"}]}`,
+			want: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := jsonEqualIgnoringNulls(tc.a, tc.b)
+			if got != tc.want {
+				t.Errorf("jsonEqualIgnoringNulls(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/provider/schema_resource.go
+++ b/internal/provider/schema_resource.go
@@ -24,33 +24,17 @@ type SchemaResource struct {
 }
 
 type SchemaResourceModel struct {
-	ID         types.String         `tfsdk:"id"`
-	SchemaName types.String         `tfsdk:"schema_name"`
-	Schema     jsontypes.Normalized `tfsdk:"schema"`
+	ID          types.String         `tfsdk:"id"`
+	SchemaName  types.String         `tfsdk:"schema_name"`
+	Schema      jsontypes.Normalized `tfsdk:"schema"`
+	ForceUpdate types.Bool           `tfsdk:"force_update"`
 }
 
-// Pinot schema JSON structure.
-type PinotSchema struct {
-	SchemaName            string         `json:"schemaName"`
-	EnableColumnBasedNull bool           `json:"enableColumnBasedNullHandling,omitempty"`
-	DimensionFieldSpecs   []FieldSpec    `json:"dimensionFieldSpecs,omitempty"`
-	MetricFieldSpecs      []FieldSpec    `json:"metricFieldSpecs,omitempty"`
-	DateTimeFieldSpecs    []DateTimeSpec `json:"dateTimeFieldSpecs,omitempty"`
-}
-
-type FieldSpec struct {
-	Name             string      `json:"name"`
-	DataType         string      `json:"dataType"`
-	SingleValueField bool        `json:"singleValueField,omitempty"`
-	DefaultNullValue interface{} `json:"defaultNullValue,omitempty"`
-}
-
-type DateTimeSpec struct {
-	Name        string `json:"name"`
-	DataType    string `json:"dataType"`
-	Format      string `json:"format"`
-	Granularity string `json:"granularity"`
-}
+// PinotSchemaConfig is a passthrough JSON object — every key the user wrote is
+// forwarded to the controller verbatim. Decoding into a typed struct silently
+// dropped fields like singleValueField=false, maxLength, transformFunction,
+// complexFieldSpecs, etc.
+type PinotSchemaConfig = map[string]interface{}
 
 func NewSchemaResource() resource.Resource {
 	return &SchemaResource{}
@@ -82,6 +66,16 @@ func (r *SchemaResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				Required:            true,
 				MarkdownDescription: "JSON configuration of the Pinot schema",
 				CustomType:          jsontypes.NormalizedType{},
+				PlanModifiers: []planmodifier.String{
+					JSONNullsIgnoredPlanModifier(),
+				},
+			},
+			"force_update": schema.BoolAttribute{
+				Optional: true,
+				MarkdownDescription: "When `true`, the provider sends `?force=true` on schema updates so the Pinot controller " +
+					"accepts backward-incompatible changes such as converting a column from single-valued to multi-valued. " +
+					"Defaults to `false`. Note: existing segments retain old metadata until reloaded — running a segment " +
+					"reload (or, for realtime tables, a force-commit) is typically required for the change to take effect on stored data.",
 			},
 		},
 	}
@@ -112,27 +106,24 @@ func (r *SchemaResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	// Parse and validate the JSON schema
-	var pinotSchema PinotSchema
+	var pinotSchema PinotSchemaConfig
 	diags := data.Schema.Unmarshal(&pinotSchema)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// Ensure schema name matches
-	if data.SchemaName.ValueString() != pinotSchema.SchemaName {
+	jsonSchemaName, _ := pinotSchema["schemaName"].(string)
+	if data.SchemaName.ValueString() != jsonSchemaName {
 		resp.Diagnostics.AddError(
 			"Schema Name Mismatch",
 			fmt.Sprintf("The schema_name attribute (%s) must match the schemaName in the JSON configuration (%s)",
-				data.SchemaName.ValueString(), pinotSchema.SchemaName),
+				data.SchemaName.ValueString(), jsonSchemaName),
 		)
 		return
 	}
 
-	// Create schema via API
-	err := r.client.CreateSchema(ctx, &pinotSchema)
-	if err != nil {
+	if err := r.client.CreateSchema(ctx, pinotSchema); err != nil {
 		resp.Diagnostics.AddError(
 			"Error Creating Pinot Schema",
 			"Could not create schema, unexpected error: "+err.Error(),
@@ -140,7 +131,7 @@ func (r *SchemaResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	data.ID = types.StringValue(pinotSchema.SchemaName)
+	data.ID = types.StringValue(jsonSchemaName)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -153,9 +144,12 @@ func (r *SchemaResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	// Get schema from API
 	schema, err := r.client.GetSchema(ctx, data.SchemaName.ValueString())
 	if err != nil {
+		if client.IsNotFound(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Reading Pinot Schema",
 			"Could not read schema ID "+data.ID.ValueString()+": "+err.Error(),
@@ -163,8 +157,11 @@ func (r *SchemaResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	// Update the schema JSON
-	schemaJSON, err := json.Marshal(schema)
+	// Pinot's GET response stamps `"indexes": null` (and other null-valued
+	// keys) onto field specs the user never wrote. Storing those into state
+	// produces a perma-diff against user HCL that omits the keys. Strip nulls
+	// so the state matches the user's representation.
+	schemaJSON, err := json.Marshal(stripNullValues(schema))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Marshaling Schema",
@@ -186,17 +183,24 @@ func (r *SchemaResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	// Parse the updated schema
-	var pinotSchema PinotSchema
+	var pinotSchema PinotSchemaConfig
 	diags := data.Schema.Unmarshal(&pinotSchema)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// Update schema via API
-	err := r.client.UpdateSchema(ctx, &pinotSchema)
-	if err != nil {
+	jsonSchemaName, _ := pinotSchema["schemaName"].(string)
+	if data.SchemaName.ValueString() != jsonSchemaName {
+		resp.Diagnostics.AddError(
+			"Schema Name Mismatch",
+			fmt.Sprintf("The schema_name attribute (%s) must match the schemaName in the JSON configuration (%s)",
+				data.SchemaName.ValueString(), jsonSchemaName),
+		)
+		return
+	}
+
+	if err := r.client.UpdateSchema(ctx, jsonSchemaName, pinotSchema, data.ForceUpdate.ValueBool()); err != nil {
 		resp.Diagnostics.AddError(
 			"Error Updating Pinot Schema",
 			"Could not update schema, unexpected error: "+err.Error(),
@@ -227,4 +231,31 @@ func (r *SchemaResource) Delete(ctx context.Context, req resource.DeleteRequest,
 
 func (r *SchemaResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("schema_name"), req, resp)
+}
+
+// stripNullValues recursively drops keys whose value is JSON null from any
+// nested object inside v. Slice elements are preserved positionally; only
+// object keys are removed. Used to filter Pinot controller responses before
+// they hit Terraform state, so user HCL that omits a key doesn't perma-diff
+// against state where the controller materialized that same key as null.
+func stripNullValues(v interface{}) interface{} {
+	switch x := v.(type) {
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(x))
+		for k, val := range x {
+			if val == nil {
+				continue
+			}
+			out[k] = stripNullValues(val)
+		}
+		return out
+	case []interface{}:
+		out := make([]interface{}, len(x))
+		for i, el := range x {
+			out[i] = stripNullValues(el)
+		}
+		return out
+	default:
+		return v
+	}
 }

--- a/internal/provider/schema_resource.go
+++ b/internal/provider/schema_resource.go
@@ -92,7 +92,7 @@ func (r *SchemaResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				Optional: true,
 				MarkdownDescription: "When `true`, the provider sends `?force=true` on schema updates so the Pinot controller " +
 					"accepts backward-incompatible changes such as converting a column from single-valued to multi-valued. " +
-					"Defaults to `false`. Note: existing segments retain old metadata until reloaded — running a segment " +
+					"If unset, it is treated as `false`. Note: existing segments retain old metadata until reloaded — running a segment " +
 					"reload (or, for realtime tables, a force-commit) is typically required for the change to take effect on stored data.",
 			},
 		},

--- a/internal/provider/schema_resource.go
+++ b/internal/provider/schema_resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -90,9 +91,11 @@ func (r *SchemaResource) Schema(ctx context.Context, req resource.SchemaRequest,
 			},
 			"force_update": schema.BoolAttribute{
 				Optional: true,
+				Computed: true,
+				Default:  booldefault.StaticBool(false),
 				MarkdownDescription: "When `true`, the provider sends `?force=true` on schema updates so the Pinot controller " +
 					"accepts backward-incompatible changes such as converting a column from single-valued to multi-valued. " +
-					"If unset, it is treated as `false`. Note: existing segments retain old metadata until reloaded — running a segment " +
+					"Defaults to `false`. Note: existing segments retain old metadata until reloaded — running a segment " +
 					"reload (or, for realtime tables, a force-commit) is typically required for the change to take effect on stored data.",
 			},
 		},
@@ -193,6 +196,9 @@ func (r *SchemaResource) Read(ctx context.Context, req resource.ReadRequest, res
 	}
 
 	data.Schema = jsontypes.NewNormalizedValue(string(schemaJSON))
+	// Pin the id from schema_name so it survives import (where only schema_name
+	// is set) and refresh, instead of relying on Create to populate it.
+	data.ID = data.SchemaName
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/schema_resource.go
+++ b/internal/provider/schema_resource.go
@@ -36,6 +36,24 @@ type SchemaResourceModel struct {
 // complexFieldSpecs, etc.
 type PinotSchemaConfig = map[string]interface{}
 
+// extractSchemaName pulls a non-empty `schemaName` string out of the parsed
+// schema JSON. Returns a targeted error so users get "schemaName is required"
+// rather than a downstream Schema Name Mismatch with an empty value.
+func extractSchemaName(m PinotSchemaConfig) (string, error) {
+	raw, ok := m["schemaName"]
+	if !ok {
+		return "", fmt.Errorf("schema JSON must include `schemaName`")
+	}
+	name, ok := raw.(string)
+	if !ok {
+		return "", fmt.Errorf("`schemaName` must be a string, got %T", raw)
+	}
+	if name == "" {
+		return "", fmt.Errorf("`schemaName` must not be empty")
+	}
+	return name, nil
+}
+
 func NewSchemaResource() resource.Resource {
 	return &SchemaResource{}
 }
@@ -113,7 +131,11 @@ func (r *SchemaResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	jsonSchemaName, _ := pinotSchema["schemaName"].(string)
+	jsonSchemaName, err := extractSchemaName(pinotSchema)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid Schema Configuration", err.Error())
+		return
+	}
 	if data.SchemaName.ValueString() != jsonSchemaName {
 		resp.Diagnostics.AddError(
 			"Schema Name Mismatch",
@@ -190,7 +212,11 @@ func (r *SchemaResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	jsonSchemaName, _ := pinotSchema["schemaName"].(string)
+	jsonSchemaName, err := extractSchemaName(pinotSchema)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid Schema Configuration", err.Error())
+		return
+	}
 	if data.SchemaName.ValueString() != jsonSchemaName {
 		resp.Diagnostics.AddError(
 			"Schema Name Mismatch",

--- a/internal/provider/schema_resource_test.go
+++ b/internal/provider/schema_resource_test.go
@@ -1,0 +1,62 @@
+package provider
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExtractSchemaName(t *testing.T) {
+	tests := []struct {
+		name      string
+		in        PinotSchemaConfig
+		want      string
+		errSubstr string
+	}{
+		{
+			name: "happy path",
+			in:   PinotSchemaConfig{"schemaName": "users"},
+			want: "users",
+		},
+		{
+			name:      "missing key",
+			in:        PinotSchemaConfig{"dimensionFieldSpecs": []interface{}{}},
+			errSubstr: "must include `schemaName`",
+		},
+		{
+			name:      "wrong type — number",
+			in:        PinotSchemaConfig{"schemaName": 42.0},
+			errSubstr: "must be a string",
+		},
+		{
+			name:      "wrong type — null",
+			in:        PinotSchemaConfig{"schemaName": nil},
+			errSubstr: "must be a string",
+		},
+		{
+			name:      "empty string",
+			in:        PinotSchemaConfig{"schemaName": ""},
+			errSubstr: "must not be empty",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := extractSchemaName(tc.in)
+			if tc.errSubstr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.errSubstr)
+				}
+				if !strings.Contains(err.Error(), tc.errSubstr) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tc.errSubstr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/provider/table_resource.go
+++ b/internal/provider/table_resource.go
@@ -5,9 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/url"
-	"os"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
@@ -82,6 +79,9 @@ func (r *TableResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				Required:            true,
 				MarkdownDescription: "JSON configuration of the Pinot table. Prefer `jsonencode({...})` for stability.",
 				CustomType:          jsontypes.NormalizedType{},
+				PlanModifiers: []planmodifier.String{
+					JSONNullsIgnoredPlanModifier(),
+				},
 			},
 			"kafka_username": schema.StringAttribute{
 				Optional:            true,
@@ -96,6 +96,9 @@ func (r *TableResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				Computed:            true,
 				Sensitive:           true,
 				MarkdownDescription: "Computed sensitive value containing the injected sasl.jaas.config when kafka_username and kafka_password are provided.",
+				PlanModifiers: []planmodifier.String{
+					SaslJaasConfigPlanModifier(),
+				},
 			},
 		},
 	}
@@ -202,8 +205,7 @@ func (r *TableResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	// Get table configuration from API by suffixed ID.
 	tableConfig, err := r.client.GetTable(ctx, data.ID.ValueString())
 	if err != nil {
-		// If the server returns 404, drop state.
-		if strings.Contains(err.Error(), "404") {
+		if client.IsNotFound(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
@@ -215,8 +217,11 @@ func (r *TableResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	}
 
 	// Normalize and store the table configuration JSON.
-	// Remove sasl.jaas.config before placing into state so we don't store the secret inside table_config.
-	cleanForState := removeSaslJaasFromTableConfig(tableConfig)
+	// Remove sasl.jaas.config so we don't store the secret inside table_config,
+	// and strip null-valued keys the controller stamps onto unset fields
+	// (e.g. "indexes": null on field configs) which would otherwise perma-diff
+	// against user HCL that omits those keys.
+	cleanForState := stripNullValues(removeSaslJaasFromTableConfig(tableConfig))
 	configJSON, err := json.Marshal(cleanForState)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -228,10 +233,10 @@ func (r *TableResource) Read(ctx context.Context, req resource.ReadRequest, resp
 
 	data.TableConfig = jsontypes.NewNormalizedValue(string(configJSON))
 
-	// Do NOT attempt to discover or populate password from remote API.
-	// We will set sasl_jaas_config to null unless the user provided it in plan/apply.
-	data.SaslJaasConfig = types.StringNull()
-
+	// sasl_jaas_config is a Computed sensitive attribute set during Create/Update
+	// from kafka_username + kafka_password. Pinot does not return secrets, so we
+	// preserve whatever's already in state rather than clobbering it to null —
+	// otherwise every apply would show a synthetic "+ sasl_jaas_config" diff.
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -277,7 +282,7 @@ func (r *TableResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	}
 
 	// Update via API (passthrough JSON).
-	if err := r.client.UpdateTable(ctx, tableConfig); err != nil {
+	if err := r.client.UpdateTable(ctx, fullTableName, tableConfig); err != nil {
 		resp.Diagnostics.AddError(
 			"Error Updating Pinot Table",
 			"Could not update table, unexpected error: "+err.Error(),
@@ -343,16 +348,12 @@ func (r *TableResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 		return
 	}
 
-	// Primary path: DELETE /tables/{logical}?type=OFFLINE|REALTIME
-	if err := deleteTableByLogical(ctx, logical, typ); err != nil {
-		// Fallback: try legacy suffixed delete via client (if supported)
-		if fallbackErr := r.client.DeleteTable(ctx, joinTableID(logical, typ)); fallbackErr != nil {
-			resp.Diagnostics.AddError(
-				"Error Deleting Pinot Table",
-				fmt.Sprintf("logical delete failed: %v; fallback delete failed: %v", err, fallbackErr),
-			)
-			return
-		}
+	if err := r.client.DeleteTableByLogical(ctx, logical, typ); err != nil {
+		resp.Diagnostics.AddError(
+			"Error Deleting Pinot Table",
+			fmt.Sprintf("Could not delete table %s_%s: %v", logical, typ, err),
+		)
+		return
 	}
 }
 
@@ -396,62 +397,17 @@ func joinTableID(logical, typ string) string {
 	return fmt.Sprintf("%s_%s", logical, typ)
 }
 
-// deleteTableByLogical performs:
-//
-//	DELETE {PINOT_CONTROLLER_URL}/tables/{logical}?type={typ}
-//
-// It honors optional env vars for Database header and auth.
-func deleteTableByLogical(ctx context.Context, logical, typ string) error {
-	base := strings.TrimRight(os.Getenv("PINOT_CONTROLLER_URL"), "/")
-	if base == "" {
-		return fmt.Errorf("PINOT_CONTROLLER_URL not set")
-	}
-
-	u, err := url.Parse(base + "/tables/" + url.PathEscape(logical))
-	if err != nil {
-		return err
-	}
-	q := u.Query()
-	q.Set("type", strings.ToUpper(typ))
-	u.RawQuery = q.Encode()
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, u.String(), nil)
-	if err != nil {
-		return err
-	}
-
-	// Optional multi-DB header
-	if db := strings.TrimSpace(os.Getenv("PINOT_DATABASE")); db != "" {
-		req.Header.Set("Database", db)
-	}
-
-	// Optional auth: basic or bearer
-	if token := strings.TrimSpace(os.Getenv("PINOT_TOKEN")); token != "" {
-		req.Header.Set("Authorization", "Basic "+token)
-	} else if uName, p := os.Getenv("PINOT_USERNAME"), os.Getenv("PINOT_PASSWORD"); uName != "" || p != "" {
-		req.SetBasicAuth(uName, p)
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	// 200/202/204 => deleted; 404 => already gone.
-	if resp.StatusCode == http.StatusOK ||
-		resp.StatusCode == http.StatusAccepted ||
-		resp.StatusCode == http.StatusNoContent ||
-		resp.StatusCode == http.StatusNotFound {
-		return nil
-	}
-
-	return fmt.Errorf("unexpected status deleting table %q type %q: %d", logical, typ, resp.StatusCode)
+// jaasEscape escapes characters that would otherwise terminate the quoted
+// JAAS string (`"` and `\`). Without this, a credential containing either of
+// those characters silently produces a malformed config that the broker rejects.
+func jaasEscape(s string) string {
+	r := strings.NewReplacer(`\`, `\\`, `"`, `\"`)
+	return r.Replace(s)
 }
 
 // buildSaslJaas constructs the sasl.jaas.config string for Kafka SCRAM.
 func buildSaslJaas(username, password string) string {
-	return fmt.Sprintf(`org.apache.kafka.common.security.scram.ScramLoginModule required username="%s" password="%s";`, username, password)
+	return fmt.Sprintf(`org.apache.kafka.common.security.scram.ScramLoginModule required username="%s" password="%s";`, jaasEscape(username), jaasEscape(password))
 }
 
 // injectKafkaSasl injects sasl.jaas.config into the provided tableConfig payload that will be sent to Pinot.

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -307,6 +307,15 @@ func (r *UserResource) ImportState(ctx context.Context, req resource.ImportState
 		return
 	}
 	username, component := parts[0], strings.ToUpper(parts[1])
+	// Validators don't run on import. Reject invalid components here so the
+	// resource never enters state in a shape Read will then 404 on.
+	if !isValidUserComponent(component) {
+		resp.Diagnostics.AddError(
+			"Invalid Import Component",
+			fmt.Sprintf("Component %q is not recognized. Must be one of: CONTROLLER, BROKER, SERVER.", parts[1]),
+		)
+		return
+	}
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("username"), username)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("component"), component)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), userID(username, component))...)
@@ -317,6 +326,15 @@ func (r *UserResource) ImportState(ctx context.Context, req resource.ImportState
 // the same username exists for multiple components.
 func userID(username, component string) string {
 	return username + "|" + component
+}
+
+func isValidUserComponent(component string) bool {
+	switch component {
+	case "CONTROLLER", "BROKER", "SERVER":
+		return true
+	default:
+		return false
+	}
 }
 
 /* ---------- helpers ---------- */

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -57,7 +57,7 @@ func (r *UserResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 		Attributes: map[string]rschema.Attribute{
 			"id": rschema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: "Resource identifier (same as `username`).",
+				MarkdownDescription: "Resource identifier in the form `username|component`. Pinot users are uniquely keyed by both.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -156,7 +156,7 @@ func (r *UserResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
-	data.ID = types.StringValue(payload.Username)
+	data.ID = types.StringValue(userID(payload.Username, payload.Component))
 
 	if u, err := r.fetchUser(ctx, payload.Username, payload.Component); err == nil {
 		data.Username = types.StringValue(u.Username)
@@ -202,7 +202,7 @@ func (r *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
-	data.ID = types.StringValue(u.Username)
+	data.ID = types.StringValue(userID(u.Username, u.Component))
 	data.Username = types.StringValue(u.Username)
 	data.Component = types.StringValue(u.Component)
 	data.Role = types.StringValue(u.Role)
@@ -297,14 +297,26 @@ func (r *UserResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 }
 
 func (r *UserResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	id := req.ID
-	if parts := strings.SplitN(id, "|", 2); len(parts) == 2 {
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("username"), parts[0])...)
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("component"), parts[1])...)
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), parts[0])...)
+	parts := strings.SplitN(req.ID, "|", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			"Import ID must be in format: username|component (e.g., admin|CONTROLLER). "+
+				"Pinot identifies users by both username and component.",
+		)
 		return
 	}
-	resource.ImportStatePassthroughID(ctx, path.Root("username"), req, resp)
+	username, component := parts[0], strings.ToUpper(parts[1])
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("username"), username)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("component"), component)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), userID(username, component))...)
+}
+
+// userID returns the canonical resource id for a Pinot user. Pinot keys users
+// by (username, component), so encoding both keeps state IDs unique even when
+// the same username exists for multiple components.
+func userID(username, component string) string {
+	return username + "|" + component
 }
 
 /* ---------- helpers ---------- */

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -7,12 +7,14 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"terraform-provider-pinot/internal/client"
 )
@@ -79,10 +81,19 @@ func (r *UserResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 			"component": rschema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "Pinot component: `CONTROLLER`, `BROKER`, or `SERVER`.",
+				Validators: []validator.String{
+					stringvalidator.OneOf("CONTROLLER", "BROKER", "SERVER"),
+				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"role": rschema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "Role: typically `ADMIN` or `USER`.",
+				Validators: []validator.String{
+					stringvalidator.OneOf("ADMIN", "USER"),
+				},
 			},
 			"tables": rschema.ListAttribute{
 				ElementType:         types.StringType,
@@ -182,6 +193,10 @@ func (r *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 
 	u, err := r.fetchUser(ctx, data.Username.ValueString(), data.Component.ValueString())
 	if err != nil {
+		if client.IsNotFound(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Error Reading Pinot User",
 			fmt.Sprintf("Could not read user %q: %v", data.Username.ValueString(), err))
 		return
@@ -221,12 +236,12 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
-	payload := map[string]interface{}{
-		"username":    plan.Username.ValueString(),
-		"component":   plan.Component.ValueString(),
-		"role":        plan.Role.ValueString(),
-		"tables":      tables,
-		"permissions": perms,
+	payload := PinotUser{
+		Username:    plan.Username.ValueString(),
+		Component:   plan.Component.ValueString(),
+		Role:        plan.Role.ValueString(),
+		Tables:      tables,
+		Permissions: perms,
 	}
 	// Pinot's ZkBasicAuthAccessControl requires a BCrypt hash in the PUT body.
 	// Sending a plaintext value causes it to silently ignore field changes (tables,
@@ -240,7 +255,7 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	//     Fail hard if the hash cannot be retrieved — silently omitting the
 	//     password would wipe the credential on the server.
 	if !plan.Password.Equal(state.Password) && !plan.Password.IsNull() && plan.Password.ValueString() != "" {
-		payload["password"] = plan.Password.ValueString()
+		payload.Password = plan.Password.ValueString()
 	} else {
 		current, err := r.fetchUser(ctx, plan.Username.ValueString(), plan.Component.ValueString())
 		if err != nil {
@@ -255,10 +270,10 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 					"set an explicit `password` in your configuration to proceed")
 			return
 		}
-		payload["password"] = current.Password
+		payload.Password = current.Password
 	}
 
-	if err := r.client.UpdateUser(ctx, payload); err != nil {
+	if err := r.client.UpdateUser(ctx, payload.Username, payload.Component, payload); err != nil {
 		resp.Diagnostics.AddError("Error Updating Pinot User", err.Error())
 		return
 	}


### PR DESCRIPTION
Schema and table updates round-trip user JSON through the provider; several issues were causing data loss, perma-diffs, or unsafe operations:

- Schema resource silently dropped any field not in its hand-rolled struct (singleValueField=false, maxLength, transformFunction, complexFieldSpecs, primaryKeyColumns, …). Switch to passthrough map[string]interface{} so the controller receives exactly what the user wrote.
- Table delete called a parallel HTTP path that read PINOT_CONTROLLER_URL and credentials from env vars, ignoring the configured provider client. Move into client.DeleteTableByLogical so HCL-only configurations work.
- User component lacked RequiresReplace; changing it would PUT against a non-existent record and could orphan the prior user. Add the modifier and OneOf validators on component/role.
- User Update built its payload as a map, marshalling nil tables as "tables": null (which some Pinot versions interpret as "clear"). Use the typed PinotUser struct so omitempty applies.
- buildSaslJaas didn't escape " or \\, producing malformed JAAS strings silently. Add jaasEscape.
- Read paths used strings.Contains(err.Error(), "404") for not-found detection. Introduce typed client.APIError + client.IsNotFound; switch schema/table/user Reads to it so out-of-band deletions clear state.
- Pinot's GET responses stamp "indexes": null (and other null keys) onto field specs the user never wrote. Strip null map values recursively before storing into state.
- table_resource.Read explicitly clobbered sasl_jaas_config to null, causing every plan to add it back. Preserve the loaded state instead.
- Add JSONNullsIgnoredPlanModifier on schema/table_config so HCL with explicit null keys (common via jsonencode of conditionals) doesn't perma-diff against null-stripped state. Real changes still flow.
- Add SaslJaasConfigPlanModifier so the Computed sasl_jaas_config no longer plans Unknown when kafka_username/kafka_password haven't changed.
- Add force_update boolean on pinot_schema. When true, append ?force=true to the schema PUT so the controller accepts backward-incompatible changes (e.g. converting a column from single-valued to multi-valued).
- Drop wasteful marshal+unmarshal round-trips in UpdateSchema, UpdateTable, and UpdateUser; take name (and component) as parameters since callers already have them.

## Related Issue

Fixes # <!-- INSERT ISSUE NUMBER -->

## Description

In plain English, describe your approach to addressing the issue linked above. For example, if you made a particular design decision, let us know why you chose this path instead of another solution.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
